### PR TITLE
Abort SoundCloud playlist scrape on partial stub-track fetch failure

### DIFF
--- a/scripts/soundcloud_scraper.py
+++ b/scripts/soundcloud_scraper.py
@@ -347,10 +347,10 @@ def get_tracks_from_playlist(  # noqa: PLR0915
                 "Fetched stub track details from API.",
                 {"requested": len(stub_track_ids), "received": len(api_tracks)},
             )
-            if len(api_tracks) == 0:
+            if len(api_tracks) < len(stub_track_ids):
                 raise RuntimeError(
-                    f"SoundCloud API returned 0 of {len(stub_track_ids)} stub tracks "
-                    f"for playlist '{playlist_name}'. Aborting to prevent data loss."
+                    f"SoundCloud API returned only {len(api_tracks)} of {len(stub_track_ids)} "
+                    f"stub tracks for playlist '{playlist_name}'. Aborting to prevent data loss."
                 )
         else:
             raise RuntimeError(


### PR DESCRIPTION
Previously only a total failure (0/N stub tracks fetched) aborted the scrape; a partial batch failure silently returned an incomplete track list, which the pruning logic then treated as tracks removed from the playlist and unlinked from the DB, even though they were still present.